### PR TITLE
Use correct plugin name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ provider:
   name: aws
 
 plugins:
-  - transmogrify
+  - serverless-transmogrify
 
 up:
   handler: transmogrify.up


### PR DESCRIPTION
While the repo is called `transmogrify`, the package is actually called `serverless-transmogrify`. I had a heck of a time figuring out why the plugin wouldn't work until I noticed this.

This problem has another, more serious, side effect that I will open another PR for shortly.