### PR TITLE
Use correct path to package for handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 class Transmogrify {
     constructor(serverless, options) {
         this.handlers = {
-            'transmogrify.up': 'node_modules/transmogrify/handlers.up',
-            'transmogrify.down': 'node_modules/transmogrify/handlers.down',
-            'transmogrify.create': 'node_modules/transmogrify/handlers.create',
-            'transmogrify.drop': 'node_modules/transmogrify/handlers.drop',
-            'transmogrify.check': 'node_modules/transmogrify/handlers.check'
+            'transmogrify.up': 'node_modules/serverless-transmogrify/handlers.up',
+            'transmogrify.down': 'node_modules/serverless-transmogrify/handlers.down',
+            'transmogrify.create': 'node_modules/serverless-transmogrify/handlers.create',
+            'transmogrify.drop': 'node_modules/serverless-transmogrify/handlers.drop',
+            'transmogrify.check': 'node_modules/serverless-transmogrify/handlers.check'
         };
         this.afterDeployFunctions = () => __awaiter(this, void 0, void 0, function* () {
             if (this.options.function) {

--- a/index.ts
+++ b/index.ts
@@ -9,11 +9,11 @@ class Transmogrify {
 
 
   handlers: {[handler:string]: string} = {
-    'transmogrify.up': 'node_modules/transmogrify/handlers.up',
-    'transmogrify.down': 'node_modules/transmogrify/handlers.down',
-    'transmogrify.create': 'node_modules/transmogrify/handlers.create',
-    'transmogrify.drop': 'node_modules/transmogrify/handlers.drop',
-    'transmogrify.check': 'node_modules/transmogrify/handlers.check'
+    'transmogrify.up': 'node_modules/serverless-transmogrify/handlers.up',
+    'transmogrify.down': 'node_modules/serverless-transmogrify/handlers.down',
+    'transmogrify.create': 'node_modules/serverless-transmogrify/handlers.create',
+    'transmogrify.drop': 'node_modules/serverless-transmogrify/handlers.drop',
+    'transmogrify.check': 'node_modules/serverless-transmogrify/handlers.check'
   }
 
   constructor(serverless: any, options: any) {


### PR DESCRIPTION
Comes from the same root problem as #1. The handlers won't be found since the path to them is incorrect when installed via npm/jest.

Ideally I think that path should be dynamically created, but I didn't find a way that worked properly.